### PR TITLE
feat: configure default random mode with auto seed

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -28,12 +28,12 @@
 
   // Game configuration
   let gameConfig: GameConfig = {
-    gameMode: 'sequential',
-    startNumber: 1,
-    endNumber: 100,
+    gameMode: 'random',
+    startNumber: 100,
+    endNumber: 999,
     timeLimit: 30,
     randomSeed: Date.now(),
-    autoRandomSeed: false,
+    autoRandomSeed: true,
     roundLimit: null,
   };
 


### PR DESCRIPTION
Update default game settings to random mode, range 100-999, and auto-seeded for a more challenging experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-665d2681-07ec-4e69-9e8d-fa8c2967ab92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-665d2681-07ec-4e69-9e8d-fa8c2967ab92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

